### PR TITLE
Implement http based calls in the second input parameter

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -12,6 +12,7 @@ type JPathConf struct {
 	Indent   int
 	Channel  chan []byte
 	Wg       sync.WaitGroup
+	Headers  []string
 }
 
 var Conf = &JPathConf{
@@ -21,4 +22,5 @@ var Conf = &JPathConf{
 	Compress: false,
 	Indent:   2,
 	Channel:  make(chan []byte, 1000),
+	Headers:  nil,
 }

--- a/input/input_test.go
+++ b/input/input_test.go
@@ -2,6 +2,7 @@ package input
 
 import (
 	"github.com/prashanth-hegde/jpath/common"
+	"github.com/prashanth-hegde/jpath/parser"
 	"reflect"
 	"testing"
 )
@@ -13,7 +14,6 @@ func TestParseInputJson(t *testing.T) {
 		expected []string
 	}{
 		{"base", `{"hello": "world"}`, []string{`{"hello": "world"}`}},
-		// todo: add stdin tests, I don't know how yet
 	}
 	for _, testcase := range testData {
 		parsed, _ := ParseInputJson(testcase.input)
@@ -24,6 +24,28 @@ func TestParseInputJson(t *testing.T) {
 		}
 		if !reflect.DeepEqual(output, expB) {
 			t.Errorf("%s --> failed", testcase.name)
+		}
+	}
+
+	httpTests := []struct {
+		name  string
+		input string
+		error bool
+	}{
+		{"base", "https://randomuser.me/api/?results=10", false},
+		{"nonexistent", "https://nonexistent.com/", true},
+		{"nonjson", "https://example.com/", false},
+	}
+	for _, testcase := range httpTests {
+		parsed, e := ParseInputJson(testcase.input)
+		if testcase.error != (e != nil) {
+			// testcase.error XOR (e == nil)
+			t.Errorf("test error: %s\n", testcase.name)
+		}
+		tokenized, e := common.Tokenize(parsed)
+		out, e := parser.ProcessExpression(".#", tokenized)
+		if e != nil && len(out) <= 0 {
+			t.Errorf("test error: %s: Expected non-zero, got zero", testcase.name)
 		}
 	}
 }

--- a/jpath.go
+++ b/jpath.go
@@ -68,6 +68,7 @@ func main() {
 	rootCmd.Flags().BoolVarP(&common.Conf.Table, "table", "t", false, "print output as table")
 	rootCmd.Flags().BoolVarP(&common.Conf.Unwrap, "unwrap", "u", false, "unwrap the output from array")
 	rootCmd.Flags().BoolVarP(&common.Conf.Compress, "compress", "c", false, "compress the output")
+	rootCmd.Flags().StringSliceVarP(&common.Conf.Headers, "header", "H", []string{}, "headers to be included for requests")
 
 	// parse input args
 	if err := rootCmd.Execute(); err != nil {

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ Note: [Input json is provided by this api](https://randomuser.me/api/?results=10
 | `-t\|--table`         | false     | Prints output in a tabular format. Works only for object types
 | `-u\|--unwrap`        | false     | Unwraps the output. Needed for processing streamed output (ex: kafka output)
 | `-c\|--compress`      | false     | Minifies the json output
+| `-H\|--header`        | false     | header values for http request
 
 #### Note
 If `-t|--table` is provided, the program attempts to print the output in tabular format and ignores other flags


### PR DESCRIPTION
The program now accepts http urls as inputs. Just like a filename reads the contents of the file and parses it, the http call makes the http call and parses the response. You can also pass headers for http calls with `-H 'key: value'` flag