### PR TITLE
Do not throw errors if field is not found

### DIFF
--- a/common/lexer.go
+++ b/common/lexer.go
@@ -7,6 +7,9 @@ import (
 )
 
 func Tokenize(json []byte) ([][]byte, error) {
+	if len(json) == 0 {
+		return nil, nil
+	}
 	var tokens [][]byte
 	v, t, _, e := parser.Get(json)
 	if e != nil {

--- a/output/table.go
+++ b/output/table.go
@@ -50,7 +50,6 @@ func determineDataTypes(jsonRow []byte) ([]KeyProp, error) {
 			}
 		}
 	default:
-
 	}
 
 	if keyProps == nil || len(keyProps) == 0 {
@@ -81,9 +80,9 @@ func PrintJsonTable(json [][]byte) error {
 		for j, k := range keyProps {
 			v, _, _, err := parser.Get(doc, k.Key)
 			if err != nil {
-				// when one field in one json document is not like others
-				return errors.Wrap(err, fmt.Sprintf("%s for document[%d] %s\n",
-					common.UnknownDataType.GetMsg(), i, k.Key))
+				// when one field in one json document is not like others,
+				// rather than throwing error, just return null instead
+				v = []byte("null")
 			}
 			printableJson[i][j] = string(v)
 		}

--- a/output/table_test.go
+++ b/output/table_test.go
@@ -34,3 +34,13 @@ func TestPrintableJson(t *testing.T) {
 		}
 	}
 }
+
+func TestMissingFields(t *testing.T) {
+	missingFieldJson := []byte(`[{"category":"SUB_LOCATION","container_type":"REACH_TRUCK"},{"container_type":"AMNESTY_BIN"}]`)
+	json, _ := common.Tokenize(missingFieldJson)
+	common.Conf.Table = true
+	e := PrintJsonTable(json)
+	if e != nil && strings.ContainsAny(e.Error(), "Key path not found") {
+		t.Errorf("expected error = %s\n\tactual error = %s\n\n", "no error", e.Error())
+	}
+}


### PR DESCRIPTION
When there's a non-existing field in the input expression, there was an error being thrown that there's a bug in the program, even through the input expression contained a non-existing field. Not throwing that error anymore and returning an empty response if that happens