### PR TITLE
Bugfix: Negative Waitgroup counter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,12 @@ jobs:
             goos: windows
     steps:
       - uses: actions/checkout@v2
-      - uses: wangyoucao577/go-release-action@v1.22
+      - uses: wangyoucao577/go-release-action@v1.25
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
-          goversion: "https://go.dev/dl/go1.17.3.linux-amd64.tar.gz"
+          goversion: "https://go.dev/dl/go1.18.1.linux-amd64.tar.gz"
           project_path: "./"
           binary_name: "jpath"
           extra_files: readme.md

--- a/input/input.go
+++ b/input/input.go
@@ -97,8 +97,8 @@ func readMultiDocumentArray(file *os.File) ([]byte, error) {
 		if len(parenthesis) == 0 && len(document) > 0 {
 			// when an individual doc is read:
 			if common.Conf.Unwrap {
-				common.Conf.Channel <- document
 				common.Conf.Wg.Add(1)
+				common.Conf.Channel <- document
 			} else {
 				// if not streaming input, add it to array to process later (example: table out)
 				documents = append(documents, document)


### PR DESCRIPTION
When using json unwrapped option, we sometimes see the program panic halfway with negative waitgroup counter.
This would happen when the channel would consume the message before the input parser could update the Wg with another work.

```
panic: sync: negative WaitGroup counter
goroutine 6 [running]:
sync.(*WaitGroup).Add(0xc00039f800, 0xffffffffffffffff)
        /usr/local/go/src/sync/waitgroup.go:74 +0x105
sync.(*WaitGroup).Done(...)
        /usr/local/go/src/sync/waitgroup.go:99
main.streamOutput(0x0)
        /github/workspace/jpath.go:39 +0x6b
created by main.main
        /github/workspace/jpath.go:84 +0x39b
```